### PR TITLE
Make GitHub detect *.txt as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+*.txt    linguist-language=Forth

--- a/r4cep/doc lab/.gitattributes
+++ b/r4cep/doc lab/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=Text


### PR DESCRIPTION
Hello,

Please merge this if you'd like GitHub to detect your `.txt` files as Forth.  Except those in the `doc lab` directory.

Thanks!
